### PR TITLE
Search PYSPARK_PYTHON in configurations

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -227,7 +227,7 @@ class SparkContext(object):
         os.environ["SPARK_BUFFER_SIZE"] = \
             str(self._jvm.PythonUtils.getSparkBufferSize(self._jsc))
 
-        self.pythonExec = os.environ.get("PYSPARK_PYTHON", 'python3')
+        self.pythonExec = os.environ.get("PYSPARK_PYTHON") or self.environment.get("PYSPARK_PYTHON", 'python3')
         self.pythonVer = "%d.%d" % sys.version_info[:2]
 
         # Broadcast's __reduce__ method stores Broadcast instances here.


### PR DESCRIPTION
Check if the PYSPARK_PYTHON was defined in the configurations passed to the context.

### What changes were proposed in this pull request?

Searches for the PYSPARK_PYTHON environment variable in the configurations passed to the Context in Python interface.

### Why are the changes needed?

When the variable is not defined in the local OS the corresponding block will use the `python3`, [line 230](https://github.com/ggarciabas/spark/blob/master/python/pyspark/context.py#L230):
```python
self.pythonExec = os.environ.get("PYSPARK_PYTHON", 'python3')
```
However, if some specific virtual environment is sent to the executors and/or the python path is changed in the executors, the configuration `spark.executorEnv.PYSPARK_PYTHON` will not be considered.